### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "axios": "^0.18.0",
     "bootstrap-vue": "^2.0.0-rc.11",
     "jquery": "^3.3.1",
-    "npm": "^6.4.1",
     "sweetalert": "^2.1.0",
     "vue": "^2.5.11",
     "vue-multiselect": "^2.1.4",


### PR DESCRIPTION

Hello JoabMendes!

It seems like you have npm as one of your (dev-) dependency in luizalabs_test.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
